### PR TITLE
Support for ATMega32U4 boards

### DIFF
--- a/devices.txt
+++ b/devices.txt
@@ -3,3 +3,4 @@ Duemilanove/Nano(ATmega328);m328p;stk500;57600;
 Duemilanove/Nano(ATmega168);m168;stk500;19200;
 Uno(ATmega328);m328p;stk500;115200;
 Mega(ATMEGA2560);atmega2560;stk500v2;115200;
+Leonardo(32U4);atmega32U4;avr109;57600


### PR DESCRIPTION
Added ATMega32U4 boards (Leonardo, Pro Micro, etc.) to the devices list.